### PR TITLE
autoscale systemd service

### DIFF
--- a/autoscale/autoscale.sh
+++ b/autoscale/autoscale.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+
+JS2AUTOSCALING="/home/ubuntu/crux/js2-autoscaling.sh"
+CONFIG="/home/ubuntu/crux/crux/vars/crux_vars.sh"
+QUEUES=("/etc/ben/queue/ecopcr.ini" "/etc/ben/queue/blast.ini" "/etc/ben/queue/ac.ini" "/etc/ben/queue/newick.ini" "/etc/ben/queue/tronko.ini" "/etc/ben/queue/qc.ini" "/etc/ben/queue/assign.ini")
+
+# Iterate over $QUEUES list
+for queue in "${QUEUES[@]}"; do
+  # run if queue exists
+  if [ -f "$queue" ]; then
+    # get server socket file
+    base_path="${queue##*/}"
+    # Remove everything after and including the last dot
+    base_name="${base_path%.*}"
+    # Replace slashes with dashes
+    # new_path="${queue//\//-}"
+    # Combine base name and modified path
+    server="/tmp/ben-${base_name}"
+
+    # check for pending jobs
+    if grep -q "type = pending" "$queue"; then
+        # scale up
+        # js2-autoscaling.sh handles if it should scale up
+        $JS2AUTOSCALING -b $server -c $CONFIG
+    else
+        # scale down
+        # js2-autoscaling.sh handles if it should scale down
+        $JS2AUTOSCALING -b $server -c $CONFIG -d
+    fi
+  fi
+done

--- a/autoscale/js2-autoscale.service
+++ b/autoscale/js2-autoscale.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Jetstream2 Autoscale VM's Service
+After=network-online.target
+
+[Service]
+User=ubuntu
+WorkingDirectory=/home/ubuntu/crux
+ExecStart=/bin/bash /home/ubuntu/crux/autoscale/autoscale.sh 
+Type=simple
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/autoscale/js2-autoscale.timer
+++ b/autoscale/js2-autoscale.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=js2-autoscale Service Timer
+
+[Timer]
+OnBootSec=15min
+OnUnitActiveSec=30min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/js2-autoscaling.sh
+++ b/js2-autoscaling.sh
@@ -64,10 +64,6 @@ getB() {
 # 4) delete server with vm_dismantle.sh
 
 
-
-
-
-
 # 5) get triggered by node_util if queued > 0 and ben nodes is empty
 # 6) check here that it's true just in case
 # 7) run vm_setup.sh to setup a server (should test with max 1 server)
@@ -79,7 +75,7 @@ if [ "$SCALE_DOWN" = "TRUE" ]; then
     queuedCount=$((queuedCount - 1)) # remove header
     if [ "$queuedCount" -eq "0" ]; then
         # loop through ben nodes and dismantle unused servers
-        nodes=$(ben nodes -s $BENSERVER | tail -n +2 | head -n -1)
+        nodes=$($BENPATH nodes -s $BENSERVER | tail -n +2 | head -n -1)
         while IFS=$' ' read -r -a fields; do
             if [ "${#fields[@]}" -ge 3 ]; then # sanity check
                 name="${fields[1]}"

--- a/tronko/assign/qc-assign.sh
+++ b/tronko/assign/qc-assign.sh
@@ -58,6 +58,8 @@ echo "Positions of columns matching 'Marker N': ${marker_positions[@]}"
 
 # Create an associative array (hash map) to store unique Marker and their corresponding FP and RP columns
 declare -A unique_values
+# set flag variable
+adapter_position_processed=false
 
 # Loop through the CSV file rows (excluding the header row)
 while IFS="," read -ra row; do
@@ -69,9 +71,10 @@ while IFS="," read -ra row; do
             fi
         fi
     done
-    if [ "$adapter_position" != "-1" ]; then
+    if [ "$adapter_position" != "-1" ] && [ "$adapter_position_processed" = false ]; then
         ADAPTER="${row[$adapter_position]}"
         ADAPTER="${ADAPTER,,}" # convert to lower case
+        adapter_position_processed=true
     fi # else using "nextera" as default
 done < <(tail -n +2 "$PROJECTID/$INPUT_METADATA" | tr -d '\r')
 

--- a/tronko/assign/qc-assign.sh
+++ b/tronko/assign/qc-assign.sh
@@ -7,6 +7,7 @@ OUTPUT="/etc/ben/output"
 INPUT_METADATA="METABARCODING.csv"
 BENPATH="/etc/ben/ben"
 ADAPTER="nextera"
+PROJECTID_LOG="$OUTPUT/projectids.txt"
 while getopts "p:b:k:s:r:" opt; do
     case $opt in
         p) PROJECTID="$OPTARG"
@@ -122,6 +123,9 @@ while IFS="," read -ra row; do
         $BENPATH add -s $BENSERVER -c "cd crux/tronko/assign; ./qc.sh -i $PROJECTID -p $marker_value -b /tmp/ben-assign -a $ADAPTER -k $AWS_ACCESS_KEY_ID -s $AWS_SECRET_ACCESS_KEY -r $AWS_DEFAULT_REGION" $job -o $OUTPUT
     fi
 done < <(tail -n +2 "$PROJECTID/eDNAExplorerPrimers.csv" | tr -d '\r')
+
+# log PROJECT ID
+echo "$PROJECTID" >> $PROJECTID_LOG
 
 # cleanup
 rm -r $PROJECTID


### PR DESCRIPTION
JS2 autoscaling
 - Systemd service that check every 30min if a ben server needs to scale up/down or stay the same. Will mainly be used for to automatically scale QC and assign VM's. I will still be manually scaling up the crux ref servers due to the current 25 VM limit.

Added a project ID log file: /etc/ben/output/projectids.txt
 - qc-assign is automatic, there's still some bugs in the QC step so i want to have a list of project ID's to check if it ran through successfully.

quick fix for adapter variable inside while loop in qc-assign.sh