### PR TITLE
upgrade to cutadapt v4

### DIFF
--- a/tronko/assign/Dockerfile
+++ b/tronko/assign/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update && apt-get upgrade -yy && apt-get install -yy build-essential
     wget -P /tmp/ "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Linux-x86_64.sh" && \
     bash "/tmp/Miniconda3-py38_4.12.0-Linux-x86_64.sh" -b -p /usr/local/miniconda
 
+# Install cutadapt using pip from Miniconda
+RUN /usr/local/miniconda/bin/python3 -m pip install --upgrade cutadapt
+
 COPY env.yml /app/env.yml
 COPY install_deps.R /app/install_deps.R
 

--- a/tronko/assign/env.yml
+++ b/tronko/assign/env.yml
@@ -20,7 +20,6 @@ dependencies:
   - certifi=2019.11.28=py27h8c360ce_1
   - chrpath=0.16=h7f98852_1002
   - curl=8.1.0=h409715c_0
-  - cutadapt=1.18=py27h14c3975_1
   - dbus=1.13.6=h5008d03_3
   - expat=2.5.0=hcb278e6_1
   - fastx_toolkit=0.0.14=hdbdd923_11


### PR DESCRIPTION
Upgrade cutadapt from v1.8 to v4

Installing it to python3's bin and keeping the rest of QC's requirements in the conda env with python2